### PR TITLE
Guard mobile menu script against missing elements

### DIFF
--- a/script.js
+++ b/script.js
@@ -3,13 +3,17 @@ const mobile_menu = document.getElementById('mobile-menu');
 const hamburger_icon = document.querySelector("#mobile-icon i");
 
 function openCloseMenu() {
-  mobile_menu.classList.toggle('block');
-  mobile_menu.classList.toggle('active');
+  if (mobile_menu) {
+    mobile_menu.classList.toggle('block');
+    mobile_menu.classList.toggle('active');
+  }
 }
 
 function changeIcon(icon) {
   icon.classList.toggle("fa-xmark");
 }
 
-mobile_icon.addEventListener('click', openCloseMenu);
+if (mobile_icon && mobile_menu) {
+  mobile_icon.addEventListener('click', openCloseMenu);
+}
 


### PR DESCRIPTION
## Summary
- prevent mobile menu toggle script from throwing when DOM nodes are absent

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b25c200ad48326aa6e248f0c75fb14