### PR TITLE
Serve static assets via CDN

### DIFF
--- a/about.html
+++ b/about.html
@@ -12,10 +12,10 @@
 
     <!-- Favicons -->
 
-    <link rel="shortcut icon" href="./public/favicon.png" type="image/x-icon">
-    <link rel="apple-touch-icon" href="./public/favicon.png">
-    <link rel="apple-touch-icon" sizes="72x72" href="./public/favicon.png">
-    <link rel="apple-touch-icon" sizes="114x114" href="./public/favicon.png">
+    <link rel="shortcut icon" href="https://aero2astro.com/public/favicon.png" type="image/x-icon">
+    <link rel="apple-touch-icon" href="https://aero2astro.com/public/favicon.png">
+    <link rel="apple-touch-icon" sizes="72x72" href="https://aero2astro.com/public/favicon.png">
+    <link rel="apple-touch-icon" sizes="114x114" href="https://aero2astro.com/public/favicon.png">
 
     <!-- Theme CSS -->
     <link href="https://aero2astro.com/october/combine/d3809ac057d5f068b756f84f9b748393-1616954640" rel="stylesheet">
@@ -28,8 +28,8 @@
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
 
     <!-- image gallary -->
-    <link rel="stylesheet" href="style.css">
-    <link rel="stylesheet" href="./gallary.css">
+    <link rel="stylesheet" href="https://aero2astro.com/home/style.css">
+    <link rel="stylesheet" href="https://aero2astro.com/home/gallary.css">
     <!--  -->
 
     <script src="https://cdn.tailwindcss.com"></script>
@@ -225,7 +225,7 @@
                     application.</p>
             </div>
             <div class="img-container min-w-fit">
-                <img src="./storyimg1.png" style="width: 300px; height: auto;">
+                <img src="https://aero2astro.com/home/storyimg1.png" style="width: 300px; height: auto;">
 
             </div>
            
@@ -235,7 +235,7 @@
         <section class="relative flex-wrap my-10 items-center flex items-center gap-8 ">
 
             <div class="img-container min-w-fit">
-                <img src="./storyimg2.png" style="width: 300px; height: auto;">
+                <img src="https://aero2astro.com/home/storyimg2.png" style="width: 300px; height: auto;">
 
             </div>
             <div class=" z-10 mt-20 flex-1">
@@ -541,8 +541,8 @@
 
 
     </script>
-    <script async src="./script.js"></script>
-    <script async src="./gallary.js"></script>
+    <script async src="https://aero2astro.com/home/script.js"></script>
+    <script async src="https://aero2astro.com/home/gallary.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </body>
 

--- a/index.html
+++ b/index.html
@@ -33,10 +33,10 @@
 
     <!-- Favicons -->
 
-    <link rel="shortcut icon" href="./public/favicon.png" type="image/x-icon">
-    <link rel="apple-touch-icon" href="./public/favicon.png">
-    <link rel="apple-touch-icon" sizes="72x72" href="./public/favicon.png">
-    <link rel="apple-touch-icon" sizes="114x114" href="./public/favicon.png">
+    <link rel="shortcut icon" href="https://aero2astro.com/public/favicon.png" type="image/x-icon">
+    <link rel="apple-touch-icon" href="https://aero2astro.com/public/favicon.png">
+    <link rel="apple-touch-icon" sizes="72x72" href="https://aero2astro.com/public/favicon.png">
+    <link rel="apple-touch-icon" sizes="114x114" href="https://aero2astro.com/public/favicon.png">
 
     <!-- Theme CSS -->
     <link href="https://aero2astro.com/october/combine/d3809ac057d5f068b756f84f9b748393-1616954640" rel="stylesheet">
@@ -49,8 +49,8 @@
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
 
     <!-- image gallary -->
-    <link rel="stylesheet" href="style.css">
-    <link rel="stylesheet" href="./gallary.css">
+    <link rel="stylesheet" href="https://aero2astro.com/home/style.css">
+    <link rel="stylesheet" href="https://aero2astro.com/home/gallary.css">
     <!--  -->
 
     <script src="https://cdn.tailwindcss.com"></script>
@@ -1105,8 +1105,8 @@
 
 
     </script>
-    <script async src="./script.js"></script>
-    <script async src="./gallary.js"></script>
+    <script async src="https://aero2astro.com/home/script.js"></script>
+    <script async src="https://aero2astro.com/home/gallary.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </body>
 


### PR DESCRIPTION
## Summary
- switch favicon, CSS, and JS links to CDN-hosted versions
- load about page images from CDN

## Testing
- `npx --yes htmlhint about.html index.html` *(fails: tag pairing and attribute warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c7ff253c8326b955cca5bf6c29b8