### PR TITLE
Specify image dimensions to preserve aspect ratios

### DIFF
--- a/about.html
+++ b/about.html
@@ -46,12 +46,12 @@
     </style>
 
     <header class="h-20 text-white  md:flex md:justify-between md:items-center fixed top-0 z-50 w-full glassmorphism">
-        <img loading="lazy" src="https://res.cloudinary.com/daaeq1zas/image/upload/v1720160607/Logo_Png-09_sifemw.png"
+        <img loading="lazy" width="1523" height="440" src="https://res.cloudinary.com/daaeq1zas/image/upload/v1720160607/Logo_Png-09_sifemw.png"
             alt="Aero2Astro" class="md:mx-10 max-sm:hidden w-[180px] md:w-[250px]">
         <nav class="relative px-2 py-4">
 
             <div class=" mx-auto flex h-10 px-2 justify-between items-center ">
-                <img loading="lazy"
+                <img loading="lazy" width="1523" height="440"
                     src="https://res.cloudinary.com/daaeq1zas/image/upload/v1720160607/Logo_Png-09_sifemw.png"
                     alt="Aero2Astro" class="md:mx-10 md:hidden w-[200px]  md:w-[250px]">
 
@@ -225,7 +225,7 @@
                     application.</p>
             </div>
             <div class="img-container min-w-fit">
-                <img src="https://aero2astro.com/home/storyimg1.png" style="width: 300px; height: auto;">
+                <img src="https://aero2astro.com/home/storyimg1.png" width="150" height="150" style="width: 300px; height: auto;">
 
             </div>
            
@@ -235,7 +235,7 @@
         <section class="relative flex-wrap my-10 items-center flex items-center gap-8 ">
 
             <div class="img-container min-w-fit">
-                <img src="https://aero2astro.com/home/storyimg2.png" style="width: 300px; height: auto;">
+                <img src="https://aero2astro.com/home/storyimg2.png" width="512" height="512" style="width: 300px; height: auto;">
 
             </div>
             <div class=" z-10 mt-20 flex-1">
@@ -443,9 +443,9 @@
             </div>
         </div>
         <hr>
-        <p class="flex gap-3 items-center mb-3">Proudly Made in <img loading="lazy"
+        <p class="flex gap-3 items-center mb-3">Proudly Made in <img loading="lazy" width="200" height="187"
                 src="https://res.cloudinary.com/daaeq1zas/image/upload/v1720167925/indianflag_eu7eve.jpg"
-                alt="proudly made in india" class="w-6 h-4"></p>
+                alt="proudly made in india" class="w-6"></p>
         <div class="d-flex align-items-center">
 
             <span class="font-weight-200">

--- a/careers.html
+++ b/careers.html
@@ -87,12 +87,12 @@
         </style>
     
         <header class="h-20 text-white  md:flex md:justify-between md:items-center fixed z-50 w-full glassmorphism">
-            <img loading="lazy" src="https://res.cloudinary.com/daaeq1zas/image/upload/v1720160607/Logo_Png-09_sifemw.png"
+            <img loading="lazy" width="1523" height="440" src="https://res.cloudinary.com/daaeq1zas/image/upload/v1720160607/Logo_Png-09_sifemw.png"
                 alt="Aero2Astro" class="md:mx-10 max-sm:hidden w-[180px] md:w-[250px]">
             <nav class="relative px-2 py-4">
     
                 <div class=" mx-auto flex h-10 px-2 justify-between items-center ">
-                    <img loading="lazy"
+                    <img loading="lazy" width="1523" height="440"
                         src="https://res.cloudinary.com/daaeq1zas/image/upload/v1720160607/Logo_Png-09_sifemw.png"
                         alt="Aero2Astro" class="md:mx-10 md:hidden w-[200px]  md:w-[250px]">
     

--- a/index.html
+++ b/index.html
@@ -67,12 +67,12 @@
     </style>
 
     <header class="h-20 text-white  md:flex md:justify-between md:items-center fixed z-50 w-full glassmorphism">
-        <img loading="lazy" src="https://res.cloudinary.com/daaeq1zas/image/upload/v1720160607/Logo_Png-09_sifemw.png"
+        <img loading="lazy" width="1523" height="440" src="https://res.cloudinary.com/daaeq1zas/image/upload/v1720160607/Logo_Png-09_sifemw.png"
             alt="Aero2Astro" class="md:mx-10 max-sm:hidden w-[180px] md:w-[250px]">
         <nav class="relative px-2 py-4">
 
             <div class=" mx-auto flex h-10 px-2 justify-between items-center ">
-                <img loading="lazy"
+                <img loading="lazy" width="1523" height="440"
                     src="https://res.cloudinary.com/daaeq1zas/image/upload/v1720160607/Logo_Png-09_sifemw.png"
                     alt="Aero2Astro" class="md:mx-10 md:hidden w-[200px]  md:w-[250px]">
 
@@ -688,7 +688,7 @@
                                                 x-transition:leave="transition ease-[cubic-bezier(0.68,-0.3,0.32,1)] duration-700"
                                                 x-transition:leave-start="opacity-100 rotate-0"
                                                 x-transition:leave-end="opacity-0 rotate-[60deg]">
-                                                <img class=" relative w-24 h-24 top-3 left-1/2 -translate-x-1/2 rounded-full"
+                                                <img class=" relative w-24 top-3 left-1/2 -translate-x-1/2 rounded-full"
                                                     :src="testimonial.img" :alt="testimonial.name">
                                             </div>
                                         </template>
@@ -1007,9 +1007,9 @@
                 </div>
             </div>
             <hr>
-            <p class="flex gap-3 items-center mb-3">Proudly Made in <img loading="lazy"
+            <p class="flex gap-3 items-center mb-3">Proudly Made in <img loading="lazy" width="200" height="187"
                     src="https://res.cloudinary.com/daaeq1zas/image/upload/v1720167925/indianflag_eu7eve.jpg"
-                    alt="proudly made in india" class="w-6 h-4"></p>
+                    alt="proudly made in india" class="w-6"></p>
             <div class="d-flex align-items-center">
 
                 <span class="font-weight-200">

--- a/soon.html
+++ b/soon.html
@@ -87,12 +87,12 @@
         </style>
     
         <header class="h-20 text-white  md:flex md:justify-between md:items-center fixed z-50 w-full glassmorphism">
-            <img loading="lazy" src="https://res.cloudinary.com/daaeq1zas/image/upload/v1720160607/Logo_Png-09_sifemw.png"
+            <img loading="lazy" width="1523" height="440" src="https://res.cloudinary.com/daaeq1zas/image/upload/v1720160607/Logo_Png-09_sifemw.png"
                 alt="Aero2Astro" class="md:mx-10 max-sm:hidden w-[180px] md:w-[250px]">
             <nav class="relative px-2 py-4">
     
                 <div class=" mx-auto flex h-10 px-2 justify-between items-center ">
-                    <img loading="lazy"
+                    <img loading="lazy" width="1523" height="440"
                         src="https://res.cloudinary.com/daaeq1zas/image/upload/v1720160607/Logo_Png-09_sifemw.png"
                         alt="Aero2Astro" class="md:mx-10 md:hidden w-[200px]  md:w-[250px]">
     


### PR DESCRIPTION
## Summary
- add explicit width and height attributes to logos and images
- remove fixed height on testimonial avatar to avoid distortion
- ensure flag images scale proportionally

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2cf3156e88326a3832cca7203e6d7