### PR TITLE
Add favicon links to site pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -12,10 +12,10 @@
 
     <!-- Favicons -->
 
-    <link rel="shortcut icon" href="https://aero2astro.com/public/favicon.png" type="image/x-icon">
-    <link rel="apple-touch-icon" href="https://aero2astro.com/public/favicon.png">
-    <link rel="apple-touch-icon" sizes="72x72" href="https://aero2astro.com/public/favicon.png">
-    <link rel="apple-touch-icon" sizes="114x114" href="https://aero2astro.com/public/favicon.png">
+    <link rel="icon" href="favicon.png" type="image/png">
+    <link rel="apple-touch-icon" href="favicon.png">
+    <link rel="apple-touch-icon" sizes="72x72" href="favicon.png">
+    <link rel="apple-touch-icon" sizes="114x114" href="favicon.png">
 
     <!-- Theme CSS -->
     <link href="https://aero2astro.com/october/combine/d3809ac057d5f068b756f84f9b748393-1616954640" rel="stylesheet">

--- a/careers.html
+++ b/careers.html
@@ -7,6 +7,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <script src="https://cdn.tailwindcss.com"></script>
         <link rel="stylesheet" href="https://aero2astro.com/home/style.css">
+        <link rel="icon" href="favicon.png" type="image/png">
 
     </head>
     <body class="simple-page">

--- a/index.html
+++ b/index.html
@@ -33,10 +33,10 @@
 
     <!-- Favicons -->
 
-    <link rel="shortcut icon" href="https://aero2astro.com/public/favicon.png" type="image/x-icon">
-    <link rel="apple-touch-icon" href="https://aero2astro.com/public/favicon.png">
-    <link rel="apple-touch-icon" sizes="72x72" href="https://aero2astro.com/public/favicon.png">
-    <link rel="apple-touch-icon" sizes="114x114" href="https://aero2astro.com/public/favicon.png">
+    <link rel="icon" href="favicon.png" type="image/png">
+    <link rel="apple-touch-icon" href="favicon.png">
+    <link rel="apple-touch-icon" sizes="72x72" href="favicon.png">
+    <link rel="apple-touch-icon" sizes="114x114" href="favicon.png">
 
     <!-- Theme CSS -->
     <link href="https://aero2astro.com/october/combine/d3809ac057d5f068b756f84f9b748393-1616954640" rel="stylesheet">

--- a/soon.html
+++ b/soon.html
@@ -7,6 +7,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <script src="https://cdn.tailwindcss.com"></script>
         <link rel="stylesheet" href="https://aero2astro.com/home/style.css">
+        <link rel="icon" href="favicon.png" type="image/png">
 
     </head>
     <body class="simple-page">


### PR DESCRIPTION
## Summary
- reference local `favicon.png` with `<link rel="icon"...>` in index and about pages
- include missing favicon link in careers and coming-soon pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d39f800883269503acd8d1276fb8