### PR TITLE
Handle missing word elements in animation script

### DIFF
--- a/about.html
+++ b/about.html
@@ -470,9 +470,14 @@
         var wordArray = [];
         var currentWord = 0;
 
-        words[currentWord].style.opacity = 1;
-        for (var i = 0; i < words.length; i++) {
-            splitLetters(words[i]);
+        if (words.length > 0) {
+            words[currentWord].style.opacity = 1;
+            for (var i = 0; i < words.length; i++) {
+                splitLetters(words[i]);
+            }
+
+            changeWord();
+            setInterval(changeWord, 4000);
         }
 
         function changeWord() {
@@ -517,10 +522,6 @@
 
             wordArray.push(letters);
         }
-
-        changeWord();
-        setInterval(changeWord, 4000);
-
 
     </script>
     <script async src="https://aero2astro.com/home/script.js"></script>

--- a/index.html
+++ b/index.html
@@ -1020,11 +1020,14 @@
         var currentWord = 0;
 
         if (words.length > 0) {
-        words[currentWord].style.opacity = 1;
-        for (var i = 0; i < words.length; i++) {
-            splitLetters(words[i]);
+            words[currentWord].style.opacity = 1;
+            for (var i = 0; i < words.length; i++) {
+                splitLetters(words[i]);
+            }
+
+            changeWord();
+            setInterval(changeWord, 4000);
         }
-    }
 
         function changeWord() {
             var cw = wordArray[currentWord];
@@ -1068,10 +1071,6 @@
 
             wordArray.push(letters);
         }
-
-        changeWord();
-        setInterval(changeWord, 4000);
-
 
     </script>
     <script async src="https://aero2astro.com/home/script.js"></script>


### PR DESCRIPTION
## Summary
- Prevent runtime errors in word animation when no `.word` elements exist
- Run word change logic only when target elements are present

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d4d47f0083268e9a275c7998cb1b